### PR TITLE
Opera67(Chrome80)対応

### DIFF
--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/BlinkImporterFactory.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/BlinkImporterFactory.cs
@@ -56,6 +56,13 @@ namespace SunokoLibrary.Application.Browsers
         { return GetDefaultProfiles().Concat(GetProfiles()); }
         public override ICookieImporter GetCookieImporter(CookieSourceInfo sourceInfo)
         { return new BlinkCookieImporter(sourceInfo, 2); }
+        public string GetStateFile(string dummy)
+        {
+            string path = null;
+            if (_dataFolder != null)
+                path = Path.Combine(_dataFolder, _stateFileName);
+            return path;
+        }
 #pragma warning restore 1591
 
         /// <summary>

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/SmartImporterFactory.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/SmartImporterFactory.cs
@@ -112,6 +112,8 @@ namespace SunokoLibrary.Application.Browsers
             return string.IsNullOrEmpty(appName) == false
                 ? new BlinkImporterFactory(appName, userDataPath, engineId: engineId) : null;
         }
+        public string GetStateFile(string cookiepath)
+        { return BlinkCookieImporter.getLocalStateFile(cookiepath); }
 #pragma warning restore 1591
     }
     /// <summary>


### PR DESCRIPTION
Opera67(Chrome80)ほかのChromium系ブラウザ対応の改良版です。
なるべくLocalStateファイルの検索を減らしたくてこうしましたが、ここまでする必要はないかもしれません。
単にgetOsKey()内部でgetLocalStateFileを呼ぶだけで十分かもしれません。
その場合はプルリクエスト却下で部分的(getLocalStateFileのところ等)に採用していただいて結構です。

・クラスBlinkImporterFactory内部にLocalStateFileのデータがあるのでそれをGetStateFileで返す。
・クラスSmartBlinkBrowserManagerにはないのでディレクトリ検索してGetStateFileで返す。
・検索をstatic getLocalStateFile にまとめた。
・ProtectedGetCookies内でLocalStateFileを１度だけ取得するよう修正