### PR TITLE
MicrosoftEdge設定ファイル追加、参照ライブラリー整理ほか

### DIFF
--- a/SnkLib.App.CookieGetter/Net4.0/Sample/Sample.csproj
+++ b/SnkLib.App.CookieGetter/Net4.0/Sample/Sample.csproj
@@ -52,9 +52,6 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto">
-      <HintPath>..\..\packages\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
@@ -70,12 +67,6 @@
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="SnkLib.App.CookieGetter">
-      <HintPath>..\SnkLib.App.CookieGetter.Forms\bin\Release\SnkLib.App.CookieGetter.dll</HintPath>
-    </Reference>
-    <Reference Include="SnkLib.App.CookieGetter.Forms">
-      <HintPath>..\SnkLib.App.CookieGetter.Forms\bin\Release\SnkLib.App.CookieGetter.Forms.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -154,6 +145,16 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\SnkLib.App.CookieGetter.Forms\SnkLib.App.CookieGetter.Forms.csproj">
+      <Project>{774f4296-1ffc-45f4-bc5f-53b3bdca3e28}</Project>
+      <Name>SnkLib.App.CookieGetter.Forms</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\SnkLib.App.CookieGetter\SnkLib.App.CookieGetter.csproj">
+      <Project>{a0609b9b-4867-4001-878c-e6cffa30b7b6}</Project>
+      <Name>SnkLib.App.CookieGetter</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -53,8 +53,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -120,6 +120,9 @@
     <Compile Include="..\..\Net4.5\SnkLib.App.CookieGetter\Factories\EdgeImporterFactory.cs">
       <Link>Factories\EdgeImporterFactory.cs</Link>
     </Compile>
+    <Compile Include="..\..\Net4.5\SnkLib.App.CookieGetter\Factories\EdgeChromiumImporterFactory.cs">
+      <Link>Factories\EdgeChromiumImporterFactory.cs</Link>
+    </Compile>
     <Compile Include="..\..\Net4.5\SnkLib.App.CookieGetter\Factories\FirefoxImporterFactory.cs">
       <Link>Factories\FirefoxImporterFactory.cs</Link>
     </Compile>

--- a/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -52,8 +52,9 @@
     <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto">
-      <HintPath>..\..\packages\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/packages.config
+++ b/SnkLib.App.CookieGetter/Net4.0/SnkLib.App.CookieGetter/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="net40" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />

--- a/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
@@ -73,6 +73,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>

--- a/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
@@ -118,6 +118,9 @@
     <Compile Include="..\SnkLib.App.CookieGetter\Factories\EdgeImporterFactory.cs">
       <Link>Core\Factories\EdgeImporterFactory.cs</Link>
     </Compile>
+    <Compile Include="..\SnkLib.App.CookieGetter\Factories\EdgeChromiumImporterFactory.cs">
+      <Link>Core\Factories\EdgeChromiumImporterFactory.cs</Link>
+    </Compile>
     <Compile Include="..\SnkLib.App.CookieGetter\Factories\FirefoxImporterFactory.cs">
       <Link>Core\Factories\FirefoxImporterFactory.cs</Link>
     </Compile>

--- a/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/CookieGetterSharp.csproj
@@ -74,8 +74,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/packages.config
+++ b/SnkLib.App.CookieGetter/Net4.5/CookieGetterSharp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
 </packages>

--- a/SnkLib.App.CookieGetter/Net4.5/LibChecker/LibChecker.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/LibChecker/LibChecker.csproj
@@ -15,7 +15,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <NoWin32Manifest>False</NoWin32Manifest>
-    <SignAssembly>True</SignAssembly>
+    <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>LibChecker.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyMode>File</AssemblyOriginatorKeyMode>

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/CookieGetters.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/CookieGetters.cs
@@ -89,7 +89,9 @@ namespace SunokoLibrary.Application
         static CookieGetters()
         {
             _importerFactories = new ICookieImporterFactory[] {
-                _ieFactory, _egFactory, _ffFactory, _chFactory,
+                //_ieFactory, _egFactory, _ffFactory, _chFactory,
+                _ieFactory, _ffFactory, _chFactory,
+                new EdgeChromiumImporterFactory(),
                 new OperaWebkitImporterFactory(),
                 new ChromiumImporterFactory(),
                 new LunascapeImporterFactory(),

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/EdgeChromiumImporterFactory.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/EdgeChromiumImporterFactory.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace SunokoLibrary.Application.Browsers
+{
+    /// <summary>
+    /// MicrosoftEdge(Chromium)からICookieImporterを取得します。
+    /// </summary>
+    public class EdgeChromiumImporterFactory : BlinkImporterFactory
+    {
+#pragma warning disable 1591
+        public EdgeChromiumImporterFactory() : base("MicrosoftEdge", "%LOCALAPPDATA%\\Microsoft\\Edge\\User Data", 1) { }
+#pragma warning restore 1591
+    }
+}

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Importers/IEPMCookieImporter.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Importers/IEPMCookieImporter.cs
@@ -77,7 +77,7 @@ namespace SunokoLibrary.Application.Browsers
             var hResult = Win32Api.GetCookiesFromProtectedModeIE(out lpszCookieData, url, key);
             return lpszCookieData;
         }
-        internal static string InternalGetCookiesWinApiOnProxy(Uri url, string key)
+        public static string InternalGetCookiesWinApiOnProxy(Uri url, string key)
         {
             var processId = Process.GetCurrentProcess().Id.ToString();
             var endpointUrl = new Uri(string.Format("net.pipe://localhost/SnkLib.App.CookieGetter.x86Proxy/{0}/Service/", processId));

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -68,6 +68,7 @@
     <Compile Include="CookieGetters.cs" />
     <Compile Include="CookieSourceSelector.cs" />
     <Compile Include="Factories\EdgeImporterFactory.cs" />
+    <Compile Include="Factories\EdgeChromiumImporterFactory.cs" />
     <Compile Include="Importers\IEFindCacheCookieImporter.cs" />
     <Compile Include="Importers\BlinkCookieImporter.cs" />
     <Compile Include="Importers\CookieImporterBase.cs" />

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -41,8 +41,9 @@
     <DocumentationFile>bin\Release\SnkLib.App.CookieGetter.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto">
-      <HintPath>..\..\..\..\..\Desktop\c#project\nicoNewStreamRecorderKakkoKariRepo2 02.05 tuujou alart_push co\nicoNewStreamRecorderKakkoKari\packages\BouncyCastle.Crypto.dll.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/SnkLib.App.CookieGetter.csproj
@@ -42,8 +42,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="BouncyCastle.Crypto, Version=1.8.1.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Utility.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Utility.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 
 namespace SunokoLibrary.Application
 {
-    internal static class Utility
+    public static class Utility
     {
         static DateTime unix = new DateTime(1970, 1, 1, 9, 0, 0);
         public static DateTime UnixTimeToDateTime(ulong UnixTime)
@@ -29,7 +29,7 @@ namespace SunokoLibrary.Application
             return path;
         }
     }
-    internal static class Win32Api
+    public static class Win32Api
     {
         public const uint INTERNET_COOKIE_THIRD_PARTY = 0x00000010;
         public const uint INTERNET_COOKIE_HTTPONLY = 0x00002000;

--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/packages.config
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="BouncyCastle" version="1.8.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.104.0" targetFramework="net45" />
 </packages>

--- a/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.Forms.nuspec
+++ b/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.Forms.nuspec
@@ -18,10 +18,10 @@
         </references>
         <dependencies>
             <group targetFramework="net45">
-                <dependency id="SnkLib.App.CookieGetter" version="2.2.1.0" />
+                <dependency id="SnkLib.App.CookieGetter" version="2.4.0.0" />
             </group>
             <group targetFramework="net40">
-                <dependency id="SnkLib.App.CookieGetter" version="2.1.0.0" />
+                <dependency id="SnkLib.App.CookieGetter" version="2.4.0.0" />
                 <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
                 <dependency id="Microsoft.Net.Http" version="2.2.29" />
             </group>

--- a/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.Forms.nuspec
+++ b/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.Forms.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>SnkLib.App.CookieGetter.Forms</id>
-        <version>1.4.0.0</version>
+        <version>1.4.1.0</version>
         <title>SnkLib.App.CookieGetter.Forms</title>
         <authors>namoshika</authors>
         <owners>namoshika</owners>

--- a/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.nuspec
+++ b/SnkLib.App.CookieGetter/Nuspecs/SnkLib.App.CookieGetter.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>SnkLib.App.CookieGetter</id>
-        <version>2.3.1.0</version>
+        <version>2.4.0.0</version>
         <title>SnkLib.App.CookieGetter</title>
         <authors>namoshika</authors>
         <owners>namoshika</owners>
@@ -20,12 +20,14 @@
             <group targetFramework="net45">
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="System.Data.SQLite.Core" version="1.0.104.0" />
+                <dependency id="BouncyCastle" version="1.8.1" />
             </group>
             <group targetFramework="net40">
                 <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
                 <dependency id="Microsoft.Bcl.Build" version="1.0.21" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="System.Data.SQLite.Core" version="1.0.104.0" />
+                <dependency id="BouncyCastle" version="1.8.1" />
             </group>
         </dependencies>
     </metadata>

--- a/SnkLib.App.CookieGetter/README.md
+++ b/SnkLib.App.CookieGetter/README.md
@@ -1,9 +1,13 @@
-GoogleChrome80の仕様変更に対応するため、SnkLib.App.CookieGetter様のプロジェクト内のコードを一部変更したものがこのリポジトリです。  
-ビルド・実行にはBouncyCastle.Cryptoが必要になります。
-  
-  
+### Chromium系ブラウザー80以降(Google Chrome, Microsoft Edge, Opera etc...)の仕様変更に対応するため、SnkLib.App.CookieGetter様のプロジェクト内のコードを一部変更したものがこのリポジトリです。  
 
-#SnkLib.App.CookieGetter
+ビルド・実行にはBouncyCastle.Cryptoが必要になります。  
+※BouncyCastle.NetCore は署名されていないのでエラーになります。 https://www.nuget.org/packages/BouncyCastle/1.8.1 を使用してください。  
+
+Visual Studioでは「パッケージの復元」で自動的にインストールされると思いますが、されない場合は以下の手順でインストールしてください。  
+- packageフォルダーに  BouncyCastle -Version 1.8.1 をインストールしてください。  
+
+
+# SnkLib.App.CookieGetter
 
 ブラウザのCookieを.NETアプリで使えるようにするライブラリです。  
 <http://com.nicovideo.jp/community/co235502> で配布されているCookieGetterSharpを元に、設計の改善を施しています。.NET4.0以上で動きます。
@@ -23,7 +27,7 @@ GoogleChrome80の仕様変更に対応するため、SnkLib.App.CookieGetter様�
 * [CookieGetterSharp](http://d.hatena.ne.jp/halxxxx/20091212/1260649353)  
   Copyright (c) 2014 halxxxx, うつろ
 
-##方針
+## 方針
 プロジェクトは以下の方針下にあります。  
 各プロジェクトはフレームワークのバージョン毎にフォルダを分けられています。
 
@@ -47,7 +51,7 @@ GoogleChrome80の仕様変更に対応するため、SnkLib.App.CookieGetter様�
 * Publish: 生成したnupkgの出力先
 * UnitTests: 動作確認。
 
-##使い方
+## 使い方
 使用したいプロジェクトへNuGetで以下のパッケージをインストールします。
 * [SnkLib.App.CookieGetter](https://www.nuget.org/packages/SnkLib.App.CookieGetter/)を追加する(必須)。
 * [SnkLib.App.CookieGetter.Forms](https://www.nuget.org/packages/SnkLib.App.CookieGetter.Forms/)を追加する  


### PR DESCRIPTION
nnn-revo2012です。
以下の修正を行いました。目的は

(1)新Edgeは次のWindows10バージョンアップで標準ブラウザになるようなのでプログラム上でChrome同様の扱いにしたい
(2)BouncyCastleをこのプロジェクト単独でインストールできるようにする
(3)参照ライブラリーの整理、コンパイル時のエラー修正
(4)NuGetファイルを作成できるようにする
   ※ローカルにNuGetファイルを置いてインストールすることができるのでそれを利用したい。
(5)README.mdの修正

csprojファイルを変更してるので、もしお使いの開発環境で読み込めなかったりエラーになったらすみません。（プロジェクトファイルとか変えてないので大丈夫だと思いますが）

・新EdgeをEdgeChromiumImporterFactoryとして登録、旧Edgeを表示から削除(プログラム上は削除していません。)
　※録画ツール（仮の設定ファイルがBlinkImporterFactoryのままでこの変更を行ってもオプションの変更なしで録画ツール（仮はEdgeで接続できることは確認しています。
・Net4.0\SampleのSnkLib.App.CookieGetterをプロジェクト参照に修正
・Net4.0\SampleのBouncyCastleの参照は使ってないようなので削除
・package にBouncyCastle 1.8.1 追加
　※新配信録画ツール（仮や放送チェックツール（仮で使用しているBouncyCastleと同一のファイルです(ハッシュで確認しました)
・BouncyCastleの参照先をpackage下に修正
　※手動でいいんで、packages に BouncyCastle.1.8.1\lib\BouncyCastle.Crypto.dll を作成してください
・LibCheckerとUnitTestsのコンパイルエラーを修正
  ※LibCheckerは実行時にエラーになるようですが・・・
・NuspecファイルにBouncyCastleを追加、バージョン指定を2.4.0/1.4.1に修正
・README.mdの修正
　※BouncyCastleのインストール・注意点について記載

                                                                                      以上