### PR TITLE
Operaがインストールされているパソコンでブラウザ一覧に「Opera Webkit」が表示されなくなったのを修正

### DIFF
--- a/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/OperaWebkitImporterFactory.cs
+++ b/SnkLib.App.CookieGetter/Net4.5/SnkLib.App.CookieGetter/Factories/OperaWebkitImporterFactory.cs
@@ -11,7 +11,7 @@ namespace SunokoLibrary.Application.Browsers
     {
 #pragma warning disable 1591
         public OperaWebkitImporterFactory()
-            : base("Opera Webkit", "%APPDATA%\\Opera Software\\Opera Stable", defaultFolder: string.Empty) { }
+            : base("Opera Webkit", "%APPDATA%\\Opera Software\\Opera Stable", 2) { }
 #pragma warning restore 1591
     }
 }


### PR DESCRIPTION
Operaがインストールされているパソコンでブラウザ一覧に「Opera Webkit」が表示されなくなった

Operaでニコニコにログインし、ブラウザを閉じてからブラウザ一蘭を表示しても「Opera Webkit」およびその後ろのログイン名は表示されない

- 原因：
  Operaの各種ユーザー情報のフォルダが これまで C:/Users/～/Opera Stable 直下だったのが
  Chromium系ブラウザと同じ/Default に変更されたので検索に失敗しているものと思われる。

- 修正：
  他のChromium系ブラウザと同じ/Default を検索するように修正。

